### PR TITLE
ci: harden verify workflow

### DIFF
--- a/.github/workflows/onpush.yaml
+++ b/.github/workflows/onpush.yaml
@@ -2,24 +2,31 @@ name: verify
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-files:
+    name: Verify files
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.11.9'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
         pip3 install -r requirements.txt
-    - name: Store python cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     - name: Verify changes
       run: |
         python -m pytest tests


### PR DESCRIPTION
## Summary

Hardens the `verify` GitHub Actions workflow: updates actions, pins to SHAs, and adds standard security/reliability guards. Passes `zizmor --pedantic` clean.

## Changes

- **Update + pin actions to commit SHAs**
  - `actions/checkout` v4 → v7.0.0
  - `actions/setup-python` v5 → v6.3.0
- **Least-privilege permissions** — `contents: read` at the top level
- **Concurrency** — cancel superseded in-progress runs on the same ref
- **Job timeout** — `timeout-minutes: 15` (last 15 runs all finished in <65s, so ~15x headroom; only trips on a genuine hang)
- **`persist-credentials: false`** on checkout (nothing here uses the token)
- **Drop the standalone `actions/cache` step** — it ran *after* install, so it was write-only and never sped anything up. Replaced with `setup-python`'s built-in `cache: 'pip'`, which restores before install and keys off `requirements.txt`.

## Verification

```
zizmor --pedantic .github/workflows/onpush.yaml
# No findings to report. Good job!
```